### PR TITLE
Add support for relative input paths.

### DIFF
--- a/README.org
+++ b/README.org
@@ -104,6 +104,7 @@ echo 'export "PATH='$currdir'/fslx/:$PATH"' >> ~/.bashrc
 ** Dependencies
 - FSL
 - A Unix like environment with a sane shell available (Linux / MacOS).
+- GNU Realink (for macOS: =brew install coreutils=). Will remove dependency eventually.
 
 ** TO DO
 - *PRIORITY*: Support relative filenames.

--- a/fslx
+++ b/fslx
@@ -73,6 +73,7 @@ operation=$1
 # We also define filenames, which are the inputs without file extensions.
 for (( i=2 ; i<=$# ; i++ )) ; do
     currfile=`echo ${!i}`
+    currfile=`readlink -f $currfile` # This adds support for relative input paths.
     inputs[$i-2]=$currfile
     filenames[$i-2]="${currfile%%.*}"
 done


### PR DESCRIPTION
This allows inputs as relative paths, however it introduces a dependency on readlink, which may not work well on MacOS since it ships with BSD's version of readlink.